### PR TITLE
fix(mcp): align tests with lifespan initialization logic

### DIFF
--- a/tests/lean_explore/mcp/test_app.py
+++ b/tests/lean_explore/mcp/test_app.py
@@ -73,13 +73,11 @@ class TestFastMCPAppLifespan:
         This ensures the application fails fast if the necessary backend
         dependency is not provided by the server startup script.
         """
-        # Ensure _lean_explore_backend_service is not set or is None
+        # Ensure both backend service and backend type are not set
         if hasattr(mcp_app, "_lean_explore_backend_service"):
             del mcp_app._lean_explore_backend_service
-
-        # Mock getattr to simulate the backend service not being
-        # found on the app instance
-        mocker.patch("lean_explore.mcp.app.getattr", return_value=None)
+        if hasattr(mcp_app, "_lean_explore_backend_type"):
+            del mcp_app._lean_explore_backend_type
 
         with pytest.raises(RuntimeError) as exc_info:
             async with mcp_app.lifespan(mcp_app):


### PR DESCRIPTION
Fix 9 failing tests by aligning test expectations with actual implementation:

- Support pre-initialized backend service in app_lifespan for testing
- Update error messages to match test assertions
- Fix test_server.py to verify attribute setting instead of constructor calls (constructors only execute in lifespan, which doesn't run when mcp_app.run() is mocked)

The main() function sets initialization parameters that are consumed asynchronously by the lifespan manager, not during main() execution.