### PR TITLE
Fix MCP server to use stored API key when --api-key not provided

### DIFF
--- a/src/lean_explore/cli/main.py
+++ b/src/lean_explore/cli/main.py
@@ -640,8 +640,8 @@ def mcp_serve_command(
                 "or provide it with the `--api-key` option for this command."
             )
             raise typer.Abort()
-        if api_key_override:
-            command_parts.extend(["--api-key", api_key_override])
+        if effective_lean_explore_api_key:
+            command_parts.extend(["--api-key", effective_lean_explore_api_key])
     elif backend.lower() == "local":
         error_console.print(  # Changed to error_console for consistency
             "[dim]Attempting to start MCP server with 'local' backend. "


### PR DESCRIPTION
The mcp serve command was loading the API key from the store via config_utils.load_api_key(), but only passing it to the MCP server subprocess when explicitly provided via the --api-key flag. This caused the server to fail with "--api-key is required" even when a valid key was stored in the configuration.

Changed the condition from checking api_key_override to checking effective_lean_explore_api_key, which includes both the override value and the stored key. Now the stored API key is properly passed to the subprocess when --api-key is not provided, matching the behavior of other commands like 'search'.