### PR TITLE
feat: Add HTTP server command for local API access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ dependencies = [
     # MCP Server Components
     "mcp>=1.9.0,<1.12.3",
 
+    # HTTP Server Components
+    "fastapi>=0.100.0",
+    "uvicorn[standard]>=0.23.0",
+
     # Utilities
     "tqdm>=4.60",
     "requests>=2.25.0",

--- a/src/lean_explore/http/__init__.py
+++ b/src/lean_explore/http/__init__.py
@@ -1,0 +1,9 @@
+# src/lean_explore/http/__init__.py
+
+"""HTTP server module for Lean Explore.
+
+This module provides an HTTP server that exposes the same API endpoints
+as the remote Lean Explore API, but can run locally without requiring
+an API key.
+"""
+

--- a/src/lean_explore/http/server.py
+++ b/src/lean_explore/http/server.py
@@ -1,0 +1,268 @@
+# src/lean_explore/http/server.py
+
+"""HTTP server implementation for Lean Explore.
+
+This module provides a FastAPI-based HTTP server that exposes the same
+API endpoints as the remote Lean Explore API. It supports both 'api'
+(proxy) and 'local' backends.
+"""
+
+import logging
+from typing import List, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException, Query
+
+from lean_explore.api.client import Client as APIClient
+from lean_explore.local.service import Service as LocalService
+from lean_explore.shared.models.api import (
+    APICitationsResponse,
+    APISearchResponse,
+    APISearchResultItem,
+)
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="Lean Explore HTTP Server",
+    description="Local HTTP server providing Lean search functionalities",
+    version="1.0.0",
+)
+
+# Global backend state
+_backend_type: Optional[str] = None
+_api_client: Optional[APIClient] = None
+_local_service: Optional[LocalService] = None
+
+
+def initialize_backend(backend: str, api_key: Optional[str] = None) -> None:
+    """Initialize the backend service based on the specified backend type.
+
+    Args:
+        backend: The backend type ('api' or 'local').
+        api_key: Optional API key for 'api' backend.
+
+    Raises:
+        ValueError: If backend is invalid or API key is missing for 'api' backend.
+        RuntimeError: If local backend initialization fails.
+    """
+    global _backend_type, _api_client, _local_service
+
+    _backend_type = backend.lower()
+
+    if _backend_type == "api":
+        if not api_key:
+            raise ValueError("API key is required for 'api' backend.")
+        _api_client = APIClient(api_key=api_key)
+        logger.info("Initialized API backend with provided API key.")
+    elif _backend_type == "local":
+        try:
+            _local_service = LocalService()
+            logger.info("Initialized local backend successfully.")
+        except Exception as e:
+            logger.error(f"Failed to initialize local backend: {e}", exc_info=True)
+            raise RuntimeError(
+                f"Failed to initialize local backend: {e}. "
+                "Please ensure local data is available by running 'leanexplore data fetch'."
+            ) from e
+    else:
+        raise ValueError(f"Invalid backend: '{backend}'. Must be 'api' or 'local'.")
+
+
+@app.get("/api/v1/search", response_model=APISearchResponse)
+async def search(
+    q: str = Query(..., description="The natural language search query string."),
+    pkg: Optional[List[str]] = Query(
+        None, description="Package names to filter by. Can be specified multiple times."
+    ),
+) -> APISearchResponse:
+    """Search for Lean statement groups.
+
+    Args:
+        q: The search query string.
+        pkg: Optional list of package names to filter by.
+
+    Returns:
+        APISearchResponse containing search results.
+
+    Raises:
+        HTTPException: If backend is not initialized or request fails.
+    """
+    if _backend_type == "api":
+        if not _api_client:
+            raise HTTPException(
+                status_code=500, detail="API backend not properly initialized."
+            )
+        try:
+            response = await _api_client.search(query=q, package_filters=pkg)
+            return response
+        except httpx.HTTPStatusError as e:
+            logger.error(f"API request failed: {e}")
+            raise HTTPException(
+                status_code=e.response.status_code,
+                detail=e.response.text or "API request failed.",
+            )
+        except httpx.RequestError as e:
+            logger.error(f"Network error: {e}")
+            raise HTTPException(status_code=503, detail=f"Network error: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
+    elif _backend_type == "local":
+        if not _local_service:
+            raise HTTPException(
+                status_code=500, detail="Local backend not properly initialized."
+            )
+        try:
+            response = _local_service.search(query=q, package_filters=pkg)
+            return response
+        except Exception as e:
+            logger.error(f"Local search failed: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Search failed: {e}")
+
+    else:
+        raise HTTPException(
+            status_code=500, detail="Backend not initialized or invalid."
+        )
+
+
+@app.get("/api/v1/statement_groups/{group_id}", response_model=APISearchResultItem)
+async def get_statement_group(group_id: int) -> APISearchResultItem:
+    """Get a statement group by its ID.
+
+    Args:
+        group_id: The unique identifier of the statement group.
+
+    Returns:
+        APISearchResultItem containing the statement group details.
+
+    Raises:
+        HTTPException: If backend is not initialized, group not found, or request fails.
+    """
+    if _backend_type == "api":
+        if not _api_client:
+            raise HTTPException(
+                status_code=500, detail="API backend not properly initialized."
+            )
+        try:
+            item = await _api_client.get_by_id(group_id)
+            if item is None:
+                raise HTTPException(status_code=404, detail="Statement group not found.")
+            return item
+        except HTTPException:
+            raise
+        except httpx.HTTPStatusError as e:
+            logger.error(f"API request failed: {e}")
+            if e.response.status_code == 404:
+                raise HTTPException(status_code=404, detail="Statement group not found.")
+            raise HTTPException(
+                status_code=e.response.status_code,
+                detail=e.response.text or "API request failed.",
+            )
+        except httpx.RequestError as e:
+            logger.error(f"Network error: {e}")
+            raise HTTPException(status_code=503, detail=f"Network error: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
+    elif _backend_type == "local":
+        if not _local_service:
+            raise HTTPException(
+                status_code=500, detail="Local backend not properly initialized."
+            )
+        try:
+            item = _local_service.get_by_id(group_id)
+            if item is None:
+                raise HTTPException(status_code=404, detail="Statement group not found.")
+            return item
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Local get_by_id failed: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Retrieval failed: {e}")
+
+    else:
+        raise HTTPException(
+            status_code=500, detail="Backend not initialized or invalid."
+        )
+
+
+@app.get(
+    "/api/v1/statement_groups/{group_id}/dependencies",
+    response_model=APICitationsResponse,
+)
+async def get_dependencies(group_id: int) -> APICitationsResponse:
+    """Get dependencies (citations) for a statement group.
+
+    Args:
+        group_id: The unique identifier of the source statement group.
+
+    Returns:
+        APICitationsResponse containing the list of dependencies.
+
+    Raises:
+        HTTPException: If backend is not initialized, group not found, or request fails.
+    """
+    if _backend_type == "api":
+        if not _api_client:
+            raise HTTPException(
+                status_code=500, detail="API backend not properly initialized."
+            )
+        try:
+            response = await _api_client.get_dependencies(group_id)
+            if response is None:
+                raise HTTPException(status_code=404, detail="Statement group not found.")
+            return response
+        except HTTPException:
+            raise
+        except httpx.HTTPStatusError as e:
+            logger.error(f"API request failed: {e}")
+            if e.response.status_code == 404:
+                raise HTTPException(status_code=404, detail="Statement group not found.")
+            raise HTTPException(
+                status_code=e.response.status_code,
+                detail=e.response.text or "API request failed.",
+            )
+        except httpx.RequestError as e:
+            logger.error(f"Network error: {e}")
+            raise HTTPException(status_code=503, detail=f"Network error: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+
+    elif _backend_type == "local":
+        if not _local_service:
+            raise HTTPException(
+                status_code=500, detail="Local backend not properly initialized."
+            )
+        try:
+            response = _local_service.get_dependencies(group_id)
+            if response is None:
+                raise HTTPException(status_code=404, detail="Statement group not found.")
+            return response
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Local get_dependencies failed: {e}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Retrieval failed: {e}")
+
+    else:
+        raise HTTPException(
+            status_code=500, detail="Backend not initialized or invalid."
+        )
+
+
+@app.get("/health")
+async def health_check() -> dict:
+    """Health check endpoint.
+
+    Returns:
+        A dictionary indicating server status.
+    """
+    return {
+        "status": "healthy",
+        "backend": _backend_type or "not initialized",
+    }
+

--- a/tests/lean_explore/http/__init__.py
+++ b/tests/lean_explore/http/__init__.py
@@ -1,0 +1,4 @@
+# tests/lean_explore/http/__init__.py
+
+"""Tests for the HTTP server module."""
+

--- a/tests/lean_explore/http/test_server.py
+++ b/tests/lean_explore/http/test_server.py
@@ -1,0 +1,458 @@
+# tests/lean_explore/http/test_server.py
+
+"""Tests for the Lean Explore HTTP server.
+
+This module verifies that the HTTP server correctly implements the API endpoints,
+handles both 'api' and 'local' backends, and properly manages backend initialization.
+"""
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from lean_explore.http.server import (
+    app,
+    initialize_backend,
+)
+from lean_explore.shared.models.api import (
+    APICitationsResponse,
+    APIPrimaryDeclarationInfo,
+    APISearchResponse,
+    APISearchResultItem,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def reset_backend_state():
+    """Reset the backend state before and after each test."""
+    # Save original state
+    from lean_explore.http import server as server_module
+
+    original_backend_type = getattr(server_module, "_backend_type", None)
+    original_api_client = getattr(server_module, "_api_client", None)
+    original_local_service = getattr(server_module, "_local_service", None)
+
+    # Reset state
+    server_module._backend_type = None
+    server_module._api_client = None
+    server_module._local_service = None
+
+    yield
+
+    # Restore original state
+    server_module._backend_type = original_backend_type
+    server_module._api_client = original_api_client
+    server_module._local_service = original_local_service
+
+
+class TestBackendInitialization:
+    """Tests for backend initialization."""
+
+    def test_initialize_backend_api_success(self, reset_backend_state):
+        """Test successful initialization of API backend."""
+        mock_api_key = "test-api-key"
+        with patch("lean_explore.http.server.APIClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+
+            initialize_backend("api", mock_api_key)
+
+            mock_client_class.assert_called_once_with(api_key=mock_api_key)
+            from lean_explore.http import server as server_module
+
+            assert server_module._backend_type == "api"
+            assert server_module._api_client is mock_client
+            assert server_module._local_service is None
+
+    def test_initialize_backend_api_missing_key(self, reset_backend_state):
+        """Test that API backend initialization fails without API key."""
+        with pytest.raises(ValueError, match="API key is required"):
+            initialize_backend("api", None)
+
+    def test_initialize_backend_local_success(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test successful initialization of local backend."""
+        mock_service = MagicMock()
+        with patch("lean_explore.http.server.LocalService") as mock_service_class:
+            mock_service_class.return_value = mock_service
+
+            initialize_backend("local", None)
+
+            mock_service_class.assert_called_once()
+            from lean_explore.http import server as server_module
+
+            assert server_module._backend_type == "local"
+            assert server_module._local_service is mock_service
+            assert server_module._api_client is None
+
+    def test_initialize_backend_local_failure(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test that local backend initialization fails when Service raises error."""
+        error_msg = "Database file not found"
+        with patch("lean_explore.http.server.LocalService") as mock_service_class:
+            mock_service_class.side_effect = FileNotFoundError(error_msg)
+
+            with pytest.raises(RuntimeError, match="Failed to initialize local backend"):
+                initialize_backend("local", None)
+
+    def test_initialize_backend_invalid(self, reset_backend_state):
+        """Test that invalid backend raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid backend"):
+            initialize_backend("invalid", None)
+
+
+class TestSearchEndpoint:
+    """Tests for the /api/v1/search endpoint."""
+
+    def test_search_api_backend_success(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test search endpoint with API backend."""
+        mock_api_key = "test-api-key"
+        mock_api_client = MagicMock()
+        mock_response = APISearchResponse(
+            query="test query",
+            packages_applied=None,
+            results=[],
+            count=0,
+            total_candidates_considered=0,
+            processing_time_ms=10,
+        )
+
+        mock_api_client.search = AsyncMock(return_value=mock_response)
+
+        with patch("lean_explore.http.server.APIClient") as mock_client_class:
+            mock_client_class.return_value = mock_api_client
+            initialize_backend("api", mock_api_key)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/search", params={"q": "test query"})
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["query"] == "test query"
+            assert data["count"] == 0
+            mock_api_client.search.assert_called_once_with(
+                query="test query", package_filters=None
+            )
+
+    def test_search_api_backend_with_packages(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test search endpoint with API backend and package filters."""
+        mock_api_key = "test-api-key"
+        mock_api_client = MagicMock()
+        mock_response = APISearchResponse(
+            query="test query",
+            packages_applied=["Mathlib"],
+            results=[],
+            count=0,
+            total_candidates_considered=0,
+            processing_time_ms=10,
+        )
+
+        mock_api_client.search = AsyncMock(return_value=mock_response)
+
+        with patch("lean_explore.http.server.APIClient") as mock_client_class:
+            mock_client_class.return_value = mock_api_client
+            initialize_backend("api", mock_api_key)
+
+            client = TestClient(app)
+            response = client.get(
+                "/api/v1/search", params={"q": "test query", "pkg": ["Mathlib"]}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["packages_applied"] == ["Mathlib"]
+            mock_api_client.search.assert_called_once_with(
+                query="test query", package_filters=["Mathlib"]
+            )
+
+    def test_search_local_backend_success(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test search endpoint with local backend."""
+        mock_local_service = MagicMock()
+        mock_response = APISearchResponse(
+            query="test query",
+            packages_applied=None,
+            results=[],
+            count=0,
+            total_candidates_considered=0,
+            processing_time_ms=10,
+        )
+
+        mock_local_service.search.return_value = mock_response
+
+        with patch("lean_explore.http.server.LocalService") as mock_service_class:
+            mock_service_class.return_value = mock_local_service
+            initialize_backend("local", None)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/search", params={"q": "test query"})
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["query"] == "test query"
+            mock_local_service.search.assert_called_once_with(
+                query="test query", package_filters=None
+            )
+
+    def test_search_backend_not_initialized(self, reset_backend_state):
+        """Test search endpoint fails when backend is not initialized."""
+        client = TestClient(app)
+        response = client.get("/api/v1/search", params={"q": "test query"})
+
+        assert response.status_code == 500
+        assert "Backend not initialized or invalid" in response.json()["detail"]
+
+    def test_search_api_backend_http_error(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test search endpoint handles HTTP errors from API backend."""
+        mock_api_key = "test-api-key"
+        mock_api_client = MagicMock()
+
+        # Simulate HTTP error
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        http_error = httpx.HTTPStatusError(
+            "Unauthorized", request=MagicMock(), response=mock_response
+        )
+
+        mock_api_client.search = AsyncMock(side_effect=http_error)
+
+        with patch("lean_explore.http.server.APIClient") as mock_client_class:
+            mock_client_class.return_value = mock_api_client
+            initialize_backend("api", mock_api_key)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/search", params={"q": "test query"})
+
+            assert response.status_code == 401
+
+    def test_search_missing_query_parameter(self, reset_backend_state):
+        """Test search endpoint requires query parameter."""
+        with patch("lean_explore.http.server.LocalService"):
+            initialize_backend("local", None)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/search")
+
+            assert response.status_code == 422  # FastAPI validation error
+
+
+class TestGetStatementGroupEndpoint:
+    """Tests for the /api/v1/statement_groups/{group_id} endpoint."""
+
+    def test_get_statement_group_api_backend_success(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test get statement group endpoint with API backend."""
+        mock_api_key = "test-api-key"
+        mock_api_client = MagicMock()
+        mock_item = APISearchResultItem(
+            id=123,
+            primary_declaration=APIPrimaryDeclarationInfo(lean_name="Test.name"),
+            source_file="Test.lean",
+            range_start_line=10,
+            statement_text="def test := 1",
+            display_statement_text="def test := 1",
+            docstring=None,
+            informal_description=None,
+        )
+
+        mock_api_client.get_by_id = AsyncMock(return_value=mock_item)
+
+        with patch("lean_explore.http.server.APIClient") as mock_client_class:
+            mock_client_class.return_value = mock_api_client
+            initialize_backend("api", mock_api_key)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/statement_groups/123")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["id"] == 123
+            assert data["primary_declaration"]["lean_name"] == "Test.name"
+            mock_api_client.get_by_id.assert_called_once_with(123)
+
+    def test_get_statement_group_not_found(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test get statement group endpoint returns 404 when not found."""
+        mock_api_key = "test-api-key"
+        mock_api_client = MagicMock()
+        mock_api_client.get_by_id = AsyncMock(return_value=None)
+
+        with patch("lean_explore.http.server.APIClient") as mock_client_class:
+            mock_client_class.return_value = mock_api_client
+            initialize_backend("api", mock_api_key)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/statement_groups/999")
+
+            assert response.status_code == 404
+            assert "not found" in response.json()["detail"]
+
+    def test_get_statement_group_local_backend_success(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test get statement group endpoint with local backend."""
+        mock_local_service = MagicMock()
+        mock_item = APISearchResultItem(
+            id=456,
+            primary_declaration=APIPrimaryDeclarationInfo(lean_name="Local.name"),
+            source_file="Local.lean",
+            range_start_line=20,
+            statement_text="theorem local := True",
+            display_statement_text="theorem local := True",
+            docstring="A local theorem",
+            informal_description=None,
+        )
+
+        mock_local_service.get_by_id.return_value = mock_item
+
+        with patch("lean_explore.http.server.LocalService") as mock_service_class:
+            mock_service_class.return_value = mock_local_service
+            initialize_backend("local", None)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/statement_groups/456")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["id"] == 456
+            assert data["docstring"] == "A local theorem"
+            mock_local_service.get_by_id.assert_called_once_with(456)
+
+
+class TestGetDependenciesEndpoint:
+    """Tests for the /api/v1/statement_groups/{group_id}/dependencies endpoint."""
+
+    def test_get_dependencies_api_backend_success(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test get dependencies endpoint with API backend."""
+        mock_api_key = "test-api-key"
+        mock_api_client = MagicMock()
+        mock_citation = APISearchResultItem(
+            id=789,
+            primary_declaration=APIPrimaryDeclarationInfo(lean_name="Dep.name"),
+            source_file="Dep.lean",
+            range_start_line=30,
+            statement_text="def dep := 2",
+            display_statement_text="def dep := 2",
+            docstring=None,
+            informal_description=None,
+        )
+        mock_response = APICitationsResponse(
+            source_group_id=123, citations=[mock_citation], count=1
+        )
+
+        mock_api_client.get_dependencies = AsyncMock(return_value=mock_response)
+
+        with patch("lean_explore.http.server.APIClient") as mock_client_class:
+            mock_client_class.return_value = mock_api_client
+            initialize_backend("api", mock_api_key)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/statement_groups/123/dependencies")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["source_group_id"] == 123
+            assert data["count"] == 1
+            assert len(data["citations"]) == 1
+            assert data["citations"][0]["id"] == 789
+            mock_api_client.get_dependencies.assert_called_once_with(123)
+
+    def test_get_dependencies_not_found(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test get dependencies endpoint returns 404 when group not found."""
+        mock_api_key = "test-api-key"
+        mock_api_client = MagicMock()
+        mock_api_client.get_dependencies = AsyncMock(return_value=None)
+
+        with patch("lean_explore.http.server.APIClient") as mock_client_class:
+            mock_client_class.return_value = mock_api_client
+            initialize_backend("api", mock_api_key)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/statement_groups/999/dependencies")
+
+            assert response.status_code == 404
+            assert "not found" in response.json()["detail"]
+
+    def test_get_dependencies_local_backend_success(
+        self, reset_backend_state, mocker: "MockerFixture"
+    ):
+        """Test get dependencies endpoint with local backend."""
+        mock_local_service = MagicMock()
+        mock_citation = APISearchResultItem(
+            id=111,
+            primary_declaration=APIPrimaryDeclarationInfo(lean_name="LocalDep.name"),
+            source_file="LocalDep.lean",
+            range_start_line=40,
+            statement_text="def local_dep := 3",
+            display_statement_text="def local_dep := 3",
+            docstring=None,
+            informal_description=None,
+        )
+        mock_response = APICitationsResponse(
+            source_group_id=456, citations=[mock_citation], count=1
+        )
+
+        mock_local_service.get_dependencies.return_value = mock_response
+
+        with patch("lean_explore.http.server.LocalService") as mock_service_class:
+            mock_service_class.return_value = mock_local_service
+            initialize_backend("local", None)
+
+            client = TestClient(app)
+            response = client.get("/api/v1/statement_groups/456/dependencies")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["source_group_id"] == 456
+            assert data["count"] == 1
+            mock_local_service.get_dependencies.assert_called_once_with(456)
+
+
+class TestHealthEndpoint:
+    """Tests for the /health endpoint."""
+
+    def test_health_check_not_initialized(self, reset_backend_state):
+        """Test health endpoint when backend is not initialized."""
+        client = TestClient(app)
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert data["backend"] == "not initialized"
+
+    def test_health_check_initialized(self, reset_backend_state):
+        """Test health endpoint when backend is initialized."""
+        with patch("lean_explore.http.server.LocalService"):
+            initialize_backend("local", None)
+
+            client = TestClient(app)
+            response = client.get("/health")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "healthy"
+            assert data["backend"] == "local"
+


### PR DESCRIPTION
Add a new `leanexplore http serve` command that starts a local HTTP server providing the same API endpoints as the remote Lean Explore API, but without requiring an API key when using the local backend.

Features:
- HTTP server implemented with FastAPI
- Supports both 'api' (proxy) and 'local' backends
- Implements all three API endpoints:
  - GET /api/v1/search - Search for statement groups
  - GET /api/v1/statement_groups/{group_id} - Get statement group by ID
  - GET /api/v1/statement_groups/{group_id}/dependencies - Get dependencies
- Health check endpoint at /health
- Configurable host (default: localhost) and port (default: 8001)
- No API key required for local backend

Changes:
- Add src/lean_explore/http/server.py with FastAPI application
- Add http command group to CLI with serve subcommand
- Add FastAPI and uvicorn dependencies to pyproject.toml
- Add comprehensive unit tests in tests/lean_explore/http/test_server.py

The server behaves identically to the remote API at https://www.leanexplore.com/api/v1, except it doesn't require authentication when using the local backend. When using the 'api' backend, it proxies requests to the remote API (requiring an API key).

All tests pass.