### PR TITLE
Update manifest generation and defaults to use GitHub releases with d…

### DIFF
--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -202,7 +202,7 @@ def generate_manifest(
         description: Optional description of this toolchain version.
         release_date: Optional release date in YYYY-MM-DD format. Defaults to today.
         assets_base_path_r2: Optional base path for R2 assets (e.g., "assets/0.3.0/").
-            Defaults to "assets/{version}/".
+            Defaults to empty string.
         cleanup_temp: If True, removes temporary compressed files after processing.
     """
     logger.info("Starting manifest generation...")
@@ -216,7 +216,7 @@ def generate_manifest(
     if release_date is None:
         release_date = datetime.now().strftime("%Y-%m-%d")
     if assets_base_path_r2 is None:
-        assets_base_path_r2 = f"assets/{version}/"
+        assets_base_path_r2 = ""
 
     # Create temporary directory for compressed files
     temp_dir = data_dir / ".manifest_temp"
@@ -325,7 +325,7 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         default=None,
         help="Base path for R2 assets (e.g., 'assets/0.3.0/'). "
-        "Defaults to 'assets/{version}/'.",
+        "Defaults to empty string.",
     )
     parser.add_argument(
         "--keep-temp",

--- a/src/lean_explore/defaults.py
+++ b/src/lean_explore/defaults.py
@@ -11,6 +11,8 @@ import os
 import pathlib
 from typing import Final
 
+import toml
+
 # --- User-Specific Data Directory ---
 # Define a base directory within the user's home folder to store
 # downloaded data assets for lean_explore.
@@ -68,14 +70,45 @@ DEFAULT_DB_URL: Final[str] = f"sqlite:///{DEFAULT_DB_PATH.resolve()}"
 # These constants are used by the data management commands to locate and
 # manage remote toolchain data assets.
 
-# Default URL for the master manifest file on R2.
+# Helper function to get the project version from pyproject.toml
+def _get_project_version() -> str:
+    """Reads the project version from pyproject.toml.
+    
+    Returns:
+        The version string from pyproject.toml.
+    """
+    # Get the path to pyproject.toml relative to this file
+    # defaults.py is at src/lean_explore/defaults.py
+    # pyproject.toml is at the project root
+    current_file = pathlib.Path(__file__)
+    project_root = current_file.parent.parent.parent
+    pyproject_path = project_root / "pyproject.toml"
+    
+    try:
+        with open(pyproject_path, "r", encoding="utf-8") as f:
+            pyproject_data = toml.load(f)
+        return pyproject_data["project"]["version"]
+    except (OSError, KeyError, toml.TomlDecodeError) as e:
+        # Fallback to a default version if reading fails
+        # This should not happen in normal operation
+        raise RuntimeError(
+            f"Failed to read version from pyproject.toml at {pyproject_path}: {e}"
+        ) from e
+
+
+# Get the project version for constructing URLs
+_PROJECT_VERSION: Final[str] = _get_project_version()
+
+# Default URL for the master manifest file on GitHub releases.
 R2_MANIFEST_DEFAULT_URL: Final[str] = (
-    "https://pub-48b75babc4664808b15520033423c765.r2.dev/manifest.json"
+    f"https://github.com/KellyJDavis/lean-explore/releases/download/v{_PROJECT_VERSION}/manifest.json"
 )
 
-# Base URL for accessing assets on R2. Specific file paths from the manifest
+# Base URL for accessing assets on GitHub releases. Specific file paths from the manifest
 # will be appended to this base.
-R2_ASSETS_BASE_URL: Final[str] = "https://pub-48b75babc4664808b15520033423c765.r2.dev/"
+R2_ASSETS_BASE_URL: Final[str] = (
+    f"https://github.com/KellyJDavis/lean-explore/releases/download/v{_PROJECT_VERSION}/"
+)
 
 # Filename for storing the currently selected active toolchain version.
 # This file will reside in LEAN_EXPLORE_USER_DATA_DIR.

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -12,8 +12,47 @@ import os
 import pathlib
 
 import pytest
+import toml
 
 from lean_explore import defaults as project_defaults
+
+
+def _get_project_version() -> str:
+    """Reads the project version from pyproject.toml.
+    
+    Returns:
+        The version string from pyproject.toml.
+    """
+    # Get the path to pyproject.toml relative to this test file
+    # test_defaults.py is at tests/test_defaults.py
+    # pyproject.toml is at the project root
+    current_file = pathlib.Path(__file__)
+    project_root = current_file.parent.parent
+    pyproject_path = project_root / "pyproject.toml"
+    
+    with open(pyproject_path, "r", encoding="utf-8") as f:
+        pyproject_data = toml.load(f)
+    return pyproject_data["project"]["version"]
+
+
+def _get_expected_manifest_url() -> str:
+    """Constructs the expected manifest URL based on the project version.
+    
+    Returns:
+        The expected manifest URL.
+    """
+    version = _get_project_version()
+    return f"https://github.com/KellyJDavis/lean-explore/releases/download/v{version}/manifest.json"
+
+
+def _get_expected_assets_base_url() -> str:
+    """Constructs the expected assets base URL based on the project version.
+    
+    Returns:
+        The expected assets base URL.
+    """
+    version = _get_project_version()
+    return f"https://github.com/KellyJDavis/lean-explore/releases/download/v{version}/"
 
 
 class TestOriginalDefaults:
@@ -133,11 +172,11 @@ class TestOriginalDefaults:
         assert project_defaults.DEFAULT_FAISS_MAP_FILENAME == "faiss_ids_map.json"
         assert (
             project_defaults.R2_MANIFEST_DEFAULT_URL
-            == "https://pub-48b75babc4664808b15520033423c765.r2.dev/manifest.json"
+            == _get_expected_manifest_url()
         )
         assert (
             project_defaults.R2_ASSETS_BASE_URL
-            == "https://pub-48b75babc4664808b15520033423c765.r2.dev/"
+            == _get_expected_assets_base_url()
         )
         assert (
             project_defaults.ACTIVE_TOOLCHAIN_CONFIG_FILENAME == "active_toolchain.txt"
@@ -285,11 +324,11 @@ class TestIsolatedDefaults:
         assert project_defaults.DEFAULT_EMBEDDING_MODEL_NAME == "BAAI/bge-base-en-v1.5"
         assert (
             project_defaults.R2_MANIFEST_DEFAULT_URL
-            == "https://pub-48b75babc4664808b15520033423c765.r2.dev/manifest.json"
+            == _get_expected_manifest_url()
         )
         assert (
             project_defaults.R2_ASSETS_BASE_URL
-            == "https://pub-48b75babc4664808b15520033423c765.r2.dev/"
+            == _get_expected_assets_base_url()
         )
 
         # Numeric search/config parameters


### PR DESCRIPTION
…ynamic versioning

- Change default assets_base_path_r2 in generate_manifest.py to empty string instead of "assets/{version}/" to support GitHub releases structure

- Update R2_MANIFEST_DEFAULT_URL and R2_ASSETS_BASE_URL in defaults.py to:
  - Read version dynamically from pyproject.toml
  - Use GitHub releases URLs: https://github.com/KellyJDavis/lean-explore/releases/download/v{version}/
  - Automatically update when project version changes

- Update tests in test_defaults.py to:
  - Read version from pyproject.toml dynamically
  - Construct expected URLs using helper functions
  - Remove hardcoded version strings to prevent test failures on version bumps

This ensures that URLs automatically reflect the current project version without requiring manual updates to defaults or tests when the version in pyproject.toml changes.