### PR TITLE
feat: add documentation site and update package name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material mkdocstrings[python] pymdown-extensions
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install lint format test test-fast test-integration test-external test-all clean
+.PHONY: help install lint format test test-fast test-integration test-external test-all clean docs docs-serve docs-build
 
 help:
 	@echo "LeanExplore Development Commands"
@@ -11,6 +11,8 @@ help:
 	@echo "make test-integration Run only integration tests"
 	@echo "make test-external    Run only external tests"
 	@echo "make test-all         Run all tests including slow, integration, and external"
+	@echo "make docs             Build documentation"
+	@echo "make docs-serve       Serve documentation locally (with auto-reload)"
 	@echo "make clean            Remove cache and build artifacts"
 
 install:
@@ -45,6 +47,14 @@ test-external:
 test-all:
 	pytest --cov=lean_explore --cov-report=term-missing --cov-report=html -v
 
+docs:
+	pip install -e ".[docs]"
+	mkdocs build
+
+docs-serve:
+	pip install -e ".[docs]"
+	mkdocs serve
+
 clean:
 	rm -rf build/
 	rm -rf dist/
@@ -53,6 +63,7 @@ clean:
 	rm -rf .ruff_cache
 	rm -rf htmlcov/
 	rm -rf .coverage
+	rm -rf site/
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,164 @@
   </a>
 </p>
 
-A search engine for Lean 4 declarations. This project provides tools and resources for exploring the Lean 4 ecosystem.
+A search engine for Lean 4 declarations. This project provides tools and resources for exploring the Lean 4 ecosystem. Lean Explore enables semantic search across multiple Lean projects including Mathlib, Batteries, Std, PhysLean, Init, and Lean, helping you discover relevant theorems, definitions, and other declarations using natural language queries.
 
-**For full documentation, please visit: [https://www.leanexplore.com/docs](https://www.leanexplore.com/docs)**
+## Features
 
-The current indexed projects include:
+- 🔍 **Semantic Search**: Find Lean declarations using natural language queries
+- 📚 **Multi-Project Support**: Search across Mathlib, Batteries, Std, PhysLean, Init, and Lean
+- 🚀 **Multiple Interfaces**: Use via CLI, Python API, HTTP server, or MCP server
+- 🏠 **Local Backend**: Run searches locally with your own data (no API key required)
+- 🔗 **Dependency Tracking**: Explore relationships between declarations
+- 📊 **Ranked Results**: Results are ranked using semantic similarity, PageRank, and lexical matching
 
-* Batteries
-* Lean
-* Init
-* Mathlib
-* PhysLean
-* Std
+## Installation
+
+Install from PyPI:
+
+```bash
+pip install lean-xplore
+```
+
+### Requirements
+
+- Python 3.10 or higher
+- pip (Python package installer)
+
+## Quick Start
+
+### Getting an API Key
+
+To use the remote API, you'll need an API key. API keys can be obtained from [https://www.leanexplore.com](https://www.leanexplore.com). Once you have your API key, configure it using:
+
+```bash
+leanexplore configure api-key YOUR_API_KEY
+```
+
+Alternatively, you can use the local backend without an API key (see [Local Backend](#local-backend) below).
+
+### Command Line
+
+Search for Lean declarations:
+
+```bash
+# Basic search
+leanexplore search "natural numbers"
+
+# Search with package filters (limit results to specific packages)
+leanexplore search "monoid" --pkg Mathlib --pkg Batteries
+
+# Limit the number of results
+leanexplore search "topology" --limit 5
+```
+
+The CLI will automatically use your configured API key, or you can use the local backend:
+
+```bash
+# Use local backend (no API key needed)
+leanexplore search "natural numbers" --backend local
+```
+
+### Python API
+
+```python
+import asyncio
+from lean_explore.api.client import Client
+
+async def main():
+    # Initialize client with API key
+    client = Client(api_key="your-api-key")
+    
+    # Perform a search
+    results = await client.search("natural numbers")
+    
+    # Display results
+    print(f"Found {len(results.items)} results")
+    for item in results.items[:5]:
+        print(f"{item.primary_declaration.lean_name}: {item.informal_name}")
+        if item.informal_description:
+            print(f"  {item.informal_description[:100]}...")
+
+asyncio.run(main())
+```
+
+You can also search multiple queries at once:
+
+```python
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    # Search multiple queries
+    results = await client.search([
+        "natural numbers",
+        "group theory",
+        "topology"
+    ])
+    
+    for result in results:
+        print(f"\nQuery: {result.query}")
+        print(f"Results: {len(result.items)}")
+
+asyncio.run(main())
+```
+
+### Local Backend
+
+Run searches locally without an API key. This is useful for offline access, faster queries, or when you want full control over the data.
+
+```bash
+# Download local data (database, embeddings, and search index)
+leanexplore data fetch
+
+# Start local HTTP server
+leanexplore http start --backend local
+```
+
+The server will be available at `http://localhost:8000`. You can query it via HTTP or use the Python client:
+
+```python
+from lean_explore.api.client import Client
+
+# Connect to local server
+client = Client(base_url="http://localhost:8000")
+
+# Use as normal (no API key needed)
+results = await client.search("natural numbers")
+```
+
+### Additional Features
+
+- **MCP Server**: Integrate with AI agents using the Model Context Protocol
+
+  ```bash
+  leanexplore mcp start --backend api --api-key YOUR_API_KEY
+  ```
+
+- **HTTP Server**: Run your own API server
+
+  ```bash
+  leanexplore http start --backend local
+  ```
+
+- **AI Chat**: Interact with an AI agent that can search Lean code
+
+  ```bash
+  leanexplore chat --backend api --api-key YOUR_API_KEY
+  ```
+
+## Documentation
+
+For detailed documentation, API reference, configuration options, and more examples, visit **[https://kellyjdavis.github.io/lean-explore](https://kellyjdavis.github.io/lean-explore)**.
+
+The documentation includes:
+
+- Complete installation and setup guides
+- Detailed CLI usage and options
+- Python API reference with examples
+- HTTP server configuration
+- MCP server integration
+- Local backend setup and data management
+- Development guides and contributing information
 
 This code is distributed under an Apache License (see [LICENSE](LICENSE)).
 

--- a/docs/api-reference/api-client.md
+++ b/docs/api-reference/api-client.md
@@ -1,0 +1,4 @@
+# API Client Reference
+
+::: lean_explore.api.client.Client
+

--- a/docs/api-reference/http-server.md
+++ b/docs/api-reference/http-server.md
@@ -1,0 +1,4 @@
+# HTTP Server Reference
+
+::: lean_explore.http.server
+

--- a/docs/api-reference/local-service.md
+++ b/docs/api-reference/local-service.md
@@ -1,0 +1,4 @@
+# Local Service Reference
+
+::: lean_explore.local.service.Service
+

--- a/docs/api-reference/mcp-tools.md
+++ b/docs/api-reference/mcp-tools.md
@@ -1,0 +1,4 @@
+# MCP Tools Reference
+
+::: lean_explore.mcp.tools
+

--- a/docs/api-reference/models.md
+++ b/docs/api-reference/models.md
@@ -1,0 +1,10 @@
+# Models Reference
+
+## API Models
+
+::: lean_explore.shared.models.api
+
+## Database Models
+
+::: lean_explore.shared.models.db
+

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,104 @@
+# Contributing
+
+Thank you for your interest in contributing to Lean Explore!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork
+3. Install in development mode:
+
+```bash
+pip install -e ".[dev]"
+```
+
+4. Run tests:
+
+```bash
+make test
+```
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.10+
+- Git
+- (Optional) Local Lean 4 installation for extractor scripts
+
+### Installation
+
+```bash
+# Clone repository
+git clone https://github.com/KellyJDavis/lean-explore.git
+cd lean-explore
+
+# Install in development mode
+pip install -e ".[dev]"
+
+# Run tests
+make test
+```
+
+## Code Style
+
+We use:
+- **Ruff** for linting and formatting
+- **Google-style** docstrings
+- **Type hints** for all functions
+
+### Formatting
+
+```bash
+# Format code
+ruff format .
+
+# Check linting
+ruff check .
+```
+
+## Testing
+
+```bash
+# Run all tests
+make test
+
+# Run with coverage
+make test-cov
+
+# Run specific test file
+pytest tests/lean_explore/api/test_client.py
+```
+
+## Documentation
+
+Documentation is built with MkDocs:
+
+```bash
+# Install docs dependencies
+pip install mkdocs-material mkdocstrings[python]
+
+# Serve locally
+mkdocs serve
+
+# Build
+mkdocs build
+```
+
+## Pull Request Process
+
+1. Create a feature branch
+2. Make your changes
+3. Add tests if applicable
+4. Ensure all tests pass
+5. Update documentation if needed
+6. Submit a pull request
+
+## Code of Conduct
+
+Be respectful and inclusive in all interactions.
+
+## Questions?
+
+Open an issue or start a discussion on GitHub.
+

--- a/docs/development/data-pipeline.md
+++ b/docs/development/data-pipeline.md
@@ -1,0 +1,91 @@
+# Data Pipeline
+
+This document describes the data processing pipeline for Lean Explore.
+
+## Overview
+
+The pipeline processes Lean 4 code to create a searchable database with semantic embeddings.
+
+## Pipeline Stages
+
+### 1. Extraction
+
+Lean scripts in `extractor/` extract:
+- Declarations and metadata
+- Dependencies between declarations
+- AST information
+
+### 2. Database Population
+
+`populate_db.py` loads data into SQLite:
+- Declarations
+- Statement groups
+- Dependencies
+- Source locations
+
+### 3. Enhancement
+
+- **Primary Declarations**: `update_primary_declarations.py` assigns primary declarations to groups
+- **PageRank**: `pagerank.py` calculates importance scores
+
+### 4. LLM Processing
+
+- **English Descriptions**: `lean_to_english.py` generates natural language descriptions
+- **Summaries**: `get_summaries.py` creates concise summaries
+
+### 5. Embedding Generation
+
+- **Prepare Input**: `prepare_embedding_input.py` formats text for embedding
+- **Generate Embeddings**: `generate_embeddings.py` creates vector embeddings
+- **Build Index**: `build_faiss_index.py` creates FAISS search index
+
+### 6. Manifest Generation
+
+`generate_manifest.py` creates manifest files for publishing data.
+
+## Data Flow
+
+```
+Lean Code
+    ↓
+Extractor Scripts
+    ↓
+JSONL Files (declarations, dependencies, AST)
+    ↓
+populate_db.py
+    ↓
+SQLite Database
+    ↓
+update_primary_declarations.py
+    ↓
+pagerank.py
+    ↓
+lean_to_english.py
+    ↓
+get_summaries.py
+    ↓
+prepare_embedding_input.py
+    ↓
+generate_embeddings.py
+    ↓
+build_faiss_index.py
+    ↓
+FAISS Index + Database
+    ↓
+generate_manifest.py
+    ↓
+Published Data
+```
+
+## Configuration
+
+Pipeline configuration is managed through:
+- `config.yml`: Main configuration file
+- `extractor/extractor_config.json`: Extractor configuration
+- Environment variables for API keys and model selection
+
+## Next Steps
+
+- [Scripts](scripts.md) - Individual script documentation
+- [Contributing](contributing.md) - How to contribute
+

--- a/docs/development/scripts.md
+++ b/docs/development/scripts.md
@@ -1,0 +1,52 @@
+# Scripts
+
+The `scripts/` directory contains utilities for processing Lean code data, generating embeddings, and building search indices.
+
+## Overview
+
+See the [Scripts README](../../scripts/README.md) for detailed documentation on all scripts.
+
+## Key Scripts
+
+### Data Processing
+
+- **`populate_db.py`**: Populates the database from Lean declaration files
+- **`update_primary_declarations.py`**: Updates primary declaration assignments
+- **`pagerank.py`**: Calculates PageRank scores for declarations
+
+### Embeddings and Search
+
+- **`prepare_embedding_input.py`**: Prepares text for embedding generation
+- **`generate_embeddings.py`**: Generates vector embeddings from text
+- **`build_faiss_index.py`**: Builds FAISS search index from embeddings
+
+### LLM Processing
+
+- **`lean_to_english.py`**: Generates English descriptions using LLMs
+- **`get_summaries.py`**: Generates summaries for statement groups
+
+### Documentation
+
+- **`generate_docs_data.py`**: Generates documentation data
+- **`generate_manifest.py`**: Creates manifest files for data toolchains
+
+## Pipeline
+
+The typical data processing pipeline:
+
+1. Extract Lean declarations (using Lean scripts in `extractor/`)
+2. Populate database: `populate_db.py`
+3. Update primary declarations: `update_primary_declarations.py`
+4. Calculate PageRank: `pagerank.py`
+5. Generate English descriptions: `lean_to_english.py`
+6. Generate summaries: `get_summaries.py`
+7. Prepare embedding input: `prepare_embedding_input.py`
+8. Generate embeddings: `generate_embeddings.py`
+9. Build FAISS index: `build_faiss_index.py`
+10. Generate manifest: `generate_manifest.py`
+
+## Next Steps
+
+- [Data Pipeline](data-pipeline.md) - Detailed pipeline documentation
+- [Contributing](contributing.md) - How to contribute
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,175 @@
+# Examples
+
+Collection of example code demonstrating Lean Explore usage.
+
+## Basic Search
+
+```python
+import asyncio
+from lean_explore.api.client import Client
+
+async def main():
+    client = Client(api_key="your-api-key")
+    results = await client.search("natural numbers")
+    
+    for item in results.items[:5]:
+        print(f"{item.primary_declaration.lean_name}")
+        print(f"  {item.informal_name}")
+        print()
+
+asyncio.run(main())
+```
+
+## Search with Filters
+
+```python
+import asyncio
+from lean_explore.api.client import Client
+
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    results = await client.search(
+        "monoid",
+        package_filters=["Mathlib", "Batteries"]
+    )
+    
+    print(f"Found {len(results.items)} results in Mathlib and Batteries")
+    for item in results.items:
+        print(f"- {item.primary_declaration.lean_name}")
+
+asyncio.run(main())
+```
+
+## Multiple Queries
+
+```python
+import asyncio
+from lean_explore.api.client import Client
+
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    queries = [
+        "natural numbers",
+        "group theory",
+        "topology"
+    ]
+    
+    results = await client.search(queries)
+    
+    for result in results:
+        print(f"\nQuery: {result.query}")
+        print(f"Results: {len(result.items)}")
+        for item in result.items[:3]:
+            print(f"  - {item.primary_declaration.lean_name}")
+
+asyncio.run(main())
+```
+
+## Get Citations
+
+```python
+import asyncio
+from lean_explore.api.client import Client
+
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    # Search first
+    search_results = await client.search("Nat")
+    if search_results.items:
+        first_result = search_results.items[0]
+        
+        # Get citations
+        citations = await client.get_citations(first_result.id)
+        
+        print(f"Citations for {first_result.primary_declaration.lean_name}:")
+        for citation in citations.citations:
+            print(f"  - {citation.lean_name}")
+
+asyncio.run(main())
+```
+
+## Local Backend
+
+```python
+import asyncio
+from lean_explore.local.service import Service
+
+async def main():
+    # Initialize local service
+    service = Service()
+    
+    # Search
+    results = await service.search("natural numbers")
+    
+    print(f"Found {len(results.items)} results")
+    for item in results.items[:5]:
+        print(f"- {item.primary_declaration.lean_name}")
+
+asyncio.run(main())
+```
+
+## HTTP Server Client
+
+```python
+import asyncio
+from lean_explore.api.client import Client
+
+async def main():
+    # Connect to local server
+    client = Client(base_url="http://localhost:8000")
+    
+    # Use as normal
+    results = await client.search("natural numbers")
+    
+    for item in results.items:
+        print(item.primary_declaration.lean_name)
+
+asyncio.run(main())
+```
+
+## Error Handling
+
+```python
+import asyncio
+import httpx
+from lean_explore.api.client import Client
+
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    try:
+        results = await client.search("natural numbers")
+        print(f"Found {len(results.items)} results")
+    except httpx.HTTPStatusError as e:
+        print(f"HTTP error: {e.response.status_code}")
+        print(f"Response: {e.response.text}")
+    except httpx.RequestError as e:
+        print(f"Request error: {e}")
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+
+asyncio.run(main())
+```
+
+## Custom Configuration
+
+```python
+import asyncio
+from lean_explore.api.client import Client
+
+async def main():
+    client = Client(
+        api_key="your-api-key",
+        base_url="https://custom-api.example.com/api/v1",
+        timeout=30.0
+    )
+    
+    results = await client.search("natural numbers")
+    print(f"Found {len(results.items)} results")
+
+asyncio.run(main())
+```
+

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,146 @@
+# Configuration
+
+Learn how to configure Lean Explore for your needs.
+
+## CLI Configuration
+
+### API Key
+
+Set your API key for the remote API:
+
+```bash
+leanexplore configure api-key YOUR_API_KEY
+```
+
+The API key is stored in your user configuration directory and will be used for all API requests.
+
+### View Current Configuration
+
+```bash
+leanexplore configure show
+```
+
+### Reset Configuration
+
+```bash
+leanexplore configure reset
+```
+
+## Environment Variables
+
+You can also configure Lean Explore using environment variables:
+
+### API Key
+
+```bash
+export LEAN_EXPLORE_API_KEY=your-api-key
+```
+
+### Base URL
+
+For local servers or custom endpoints:
+
+```bash
+export LEAN_EXPLORE_BASE_URL=http://localhost:8000
+```
+
+## Python Configuration
+
+### Using Environment Variables
+
+```python
+import os
+from lean_explore.api.client import Client
+
+# Read from environment
+api_key = os.getenv("LEAN_EXPLORE_API_KEY")
+base_url = os.getenv("LEAN_EXPLORE_BASE_URL", "https://www.leanexplore.com/api/v1")
+
+client = Client(api_key=api_key, base_url=base_url)
+```
+
+### Direct Configuration
+
+```python
+from lean_explore.api.client import Client
+
+# Configure directly
+client = Client(
+    api_key="your-api-key",
+    base_url="https://www.leanexplore.com/api/v1",
+    timeout=30.0  # Custom timeout
+)
+```
+
+## Local Backend Configuration
+
+### Data Directory
+
+By default, local data is stored in `~/.leanexplore/data`. You can configure this:
+
+```python
+from lean_explore.local.service import Service
+from lean_explore import defaults
+
+# Custom data directory
+service = Service(data_dir="/path/to/custom/data")
+```
+
+### Database URL
+
+For local backend, you can specify a custom database URL:
+
+```python
+from lean_explore.local.service import Service
+
+service = Service(
+    db_url="sqlite:///path/to/custom/database.db"
+)
+```
+
+## HTTP Server Configuration
+
+### Backend Selection
+
+```bash
+# Use remote API backend
+leanexplore http start --backend api --api-key YOUR_API_KEY
+
+# Use local backend
+leanexplore http start --backend local
+```
+
+### Port and Host
+
+```bash
+# Custom port
+leanexplore http start --backend local --port 8080
+
+# Custom host
+leanexplore http start --backend local --host 0.0.0.0
+```
+
+## MCP Server Configuration
+
+```bash
+# API backend
+leanexplore mcp start --backend api --api-key YOUR_API_KEY
+
+# Local backend
+leanexplore mcp start --backend local
+```
+
+## Configuration Files
+
+Configuration is stored in:
+- **macOS/Linux**: `~/.config/leanexplore/config.toml`
+- **Windows**: `%APPDATA%\leanexplore\config.toml`
+
+The configuration file uses TOML format:
+
+```toml
+[api]
+api_key = "your-api-key"
+base_url = "https://www.leanexplore.com/api/v1"
+```
+

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,59 @@
+# Installation
+
+This guide will help you install Lean Explore and set up your environment.
+
+## Requirements
+
+- Python 3.10 or higher
+- pip (Python package installer)
+
+## Install from PyPI
+
+The easiest way to install Lean Explore is using pip:
+
+```bash
+pip install lean-xplore
+```
+
+## Install from Source
+
+If you want to install from the source code:
+
+```bash
+# Clone the repository
+git clone https://github.com/KellyJDavis/lean-explore.git
+cd lean-explore
+
+# Install in development mode
+pip install -e .
+
+# Or install with development dependencies
+pip install -e ".[dev]"
+```
+
+## Verify Installation
+
+After installation, verify that the CLI is available:
+
+```bash
+leanexplore --help
+```
+
+You should see the help output for the Lean Explore CLI.
+
+## Optional: Local Backend Setup
+
+If you want to use the local backend (instead of the remote API), you'll need to download the data:
+
+```bash
+# Fetch local data
+leanexplore data fetch
+```
+
+This will download the necessary database, embeddings, and index files to enable local search.
+
+## Next Steps
+
+- [Quick Start Guide](quickstart.md) - Learn how to use Lean Explore
+- [Configuration](configuration.md) - Configure API keys and settings
+

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,113 @@
+# Quick Start
+
+Get up and running with Lean Explore in minutes.
+
+## Using the CLI
+
+### Basic Search
+
+Search for Lean declarations using natural language:
+
+```bash
+leanexplore search "natural numbers"
+```
+
+### Configure API Key
+
+To use the remote API, you'll need an API key:
+
+```bash
+leanexplore configure api-key YOUR_API_KEY
+```
+
+### Search with Package Filters
+
+Filter results to specific packages:
+
+```bash
+leanexplore search "monoid" --pkg Mathlib --pkg Batteries
+```
+
+## Using Python API
+
+### Basic Example
+
+```python
+import asyncio
+from lean_explore.api.client import Client
+
+async def main():
+    # Initialize client with API key
+    client = Client(api_key="your-api-key")
+    
+    # Perform a search
+    results = await client.search("natural numbers")
+    
+    # Print results
+    for item in results.items[:5]:  # Top 5 results
+        print(f"{item.primary_declaration.lean_name}: {item.informal_name}")
+
+asyncio.run(main())
+```
+
+### Search Multiple Queries
+
+```python
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    # Search multiple queries at once
+    results = await client.search([
+        "natural numbers",
+        "group theory",
+        "topology"
+    ])
+    
+    for result in results:
+        print(f"Query: {result.query}")
+        print(f"Found {len(result.items)} results\n")
+
+asyncio.run(main())
+```
+
+## Using Local Backend
+
+### Start Local HTTP Server
+
+```bash
+# First, fetch local data
+leanexplore data fetch
+
+# Start the server
+leanexplore http start --backend local
+```
+
+The server will be available at `http://localhost:8000`.
+
+### Query the Local Server
+
+```bash
+curl "http://localhost:8000/api/v1/search?q=natural+numbers"
+```
+
+Or use the Python client with a custom base URL:
+
+```python
+client = Client(base_url="http://localhost:8000")
+results = await client.search("natural numbers")
+```
+
+## Using MCP Server
+
+The MCP (Model Context Protocol) server allows AI agents to interact with Lean Explore:
+
+```bash
+leanexplore mcp start --backend api --api-key YOUR_API_KEY
+```
+
+## Next Steps
+
+- [CLI Usage](../user-guide/cli.md) - Detailed CLI documentation
+- [API Client](../user-guide/api-client.md) - Python API guide
+- [Configuration](configuration.md) - Advanced configuration options
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,100 @@
+# Lean Explore
+
+**A search engine for Lean 4 declarations**
+
+Lean Explore is a powerful search engine designed to help you discover and explore declarations in the Lean 4 ecosystem. It provides semantic search capabilities across multiple Lean projects including Mathlib, Batteries, Std, and more.
+
+## Features
+
+- 🔍 **Semantic Search**: Find Lean declarations using natural language queries
+- 📚 **Multi-Project Support**: Search across Mathlib, Batteries, Std, PhysLean, Init, and Lean
+- 🚀 **Multiple Interfaces**: Use via CLI, Python API, HTTP server, or MCP server
+- 🏠 **Local Backend**: Run searches locally with your own data
+- 🔗 **Dependency Tracking**: Explore relationships between declarations
+- 📊 **Ranked Results**: Results are ranked using semantic similarity, PageRank, and lexical matching
+
+## Quick Links
+
+- [Installation](getting-started/installation.md) - Get started with Lean Explore
+- [Quick Start Guide](getting-started/quickstart.md) - Learn the basics in minutes
+- [CLI Usage](user-guide/cli.md) - Command-line interface documentation
+- [API Reference](api-reference/api-client.md) - Python API documentation
+
+## Current Indexed Projects
+
+The following Lean projects are currently indexed:
+
+- **Batteries** - Extended standard library for Lean 4
+- **Lean** - Core Lean 4 library
+- **Init** - Initialization and basic types
+- **Mathlib** - Mathematics library for Lean 4
+- **PhysLean** - Physics library for Lean 4
+- **Std** - Standard library for Lean 4
+
+## Installation
+
+```bash
+pip install lean-xplore
+```
+
+For more details, see the [Installation Guide](getting-started/installation.md).
+
+## Basic Usage
+
+### CLI
+
+```bash
+# Search for declarations
+leanexplore search "natural numbers"
+
+# Configure API key
+leanexplore configure api-key YOUR_API_KEY
+
+# Start local HTTP server
+leanexplore http start --backend local
+```
+
+### Python API
+
+```python
+from lean_explore.api.client import Client
+
+client = Client(api_key="your-api-key")
+results = await client.search("natural numbers")
+```
+
+### HTTP Server
+
+```bash
+# Start server
+leanexplore http start --backend local
+
+# Query via HTTP
+curl "http://localhost:8000/api/v1/search?q=natural+numbers"
+```
+
+## Documentation Structure
+
+- **[Getting Started](getting-started/installation.md)**: Installation and setup
+- **[User Guide](user-guide/cli.md)**: How to use different interfaces
+- **[API Reference](api-reference/api-client.md)**: Complete API documentation
+- **[Development](development/scripts.md)**: Contributing and development guides
+
+## Citation
+
+If you use Lean Explore in your research or work, please cite it:
+
+```bibtex
+@software{Asher_LeanExplore_2025,
+  author = {Asher, Justin},
+  title = {{LeanExplore: A search engine for Lean 4 declarations}},
+  year = {2025},
+  url = {http://www.leanexplore.com},
+  note = {GitHub repository: https://github.com/justincasher/lean-explore}
+}
+```
+
+## License
+
+This project is distributed under the Apache License 2.0. See [LICENSE](https://github.com/KellyJDavis/lean-explore/blob/main/LICENSE) for details.
+

--- a/docs/user-guide/api-client.md
+++ b/docs/user-guide/api-client.md
@@ -1,0 +1,188 @@
+# API Client
+
+The Python API client provides programmatic access to Lean Explore search functionality.
+
+## Basic Usage
+
+### Initialization
+
+```python
+from lean_explore.api.client import Client
+
+# With API key
+client = Client(api_key="your-api-key")
+
+# With custom base URL (for local servers)
+client = Client(base_url="http://localhost:8000")
+
+# Both API key and custom URL
+client = Client(
+    api_key="your-api-key",
+    base_url="https://custom-api.example.com/api/v1"
+)
+```
+
+### Single Search
+
+```python
+import asyncio
+
+async def main():
+    client = Client(api_key="your-api-key")
+    results = await client.search("natural numbers")
+    
+    print(f"Found {len(results.items)} results")
+    for item in results.items:
+        print(f"- {item.primary_declaration.lean_name}")
+
+asyncio.run(main())
+```
+
+### Multiple Searches
+
+```python
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    queries = ["natural numbers", "group theory", "topology"]
+    results = await client.search(queries)
+    
+    for result in results:
+        print(f"Query: {result.query}")
+        print(f"Results: {len(result.items)}\n")
+
+asyncio.run(main())
+```
+
+## Advanced Usage
+
+### Package Filtering
+
+```python
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    # Filter by package
+    results = await client.search(
+        "monoid",
+        package_filters=["Mathlib", "Batteries"]
+    )
+    
+    for item in results.items:
+        print(f"{item.primary_declaration.lean_name}")
+
+asyncio.run(main())
+```
+
+### Getting Citations
+
+```python
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    # Search first
+    search_results = await client.search("natural numbers")
+    first_result = search_results.items[0]
+    
+    # Get citations for a result
+    citations = await client.get_citations(first_result.id)
+    
+    print(f"Citations for {first_result.primary_declaration.lean_name}:")
+    for citation in citations.citations:
+        print(f"- {citation.lean_name}")
+
+asyncio.run(main())
+```
+
+### Error Handling
+
+```python
+import httpx
+
+async def main():
+    client = Client(api_key="your-api-key")
+    
+    try:
+        results = await client.search("natural numbers")
+    except httpx.HTTPStatusError as e:
+        print(f"HTTP error: {e.response.status_code}")
+    except httpx.RequestError as e:
+        print(f"Request error: {e}")
+
+asyncio.run(main())
+```
+
+## Response Models
+
+### APISearchResponse
+
+```python
+from lean_explore.shared.models.api import APISearchResponse
+
+results: APISearchResponse = await client.search("query")
+
+# Access properties
+results.query  # The search query
+results.items  # List of APISearchResultItem
+```
+
+### APISearchResultItem
+
+```python
+item = results.items[0]
+
+# Primary declaration
+item.primary_declaration.lean_name
+item.primary_declaration.decl_type
+
+# Informal description
+item.informal_name
+item.informal_description
+
+# Statement group ID
+item.id
+
+# Score
+item.score
+```
+
+### APICitationsResponse
+
+```python
+citations = await client.get_citations(item_id)
+
+# List of citations
+for citation in citations.citations:
+    print(citation.lean_name)
+    print(citation.decl_type)
+```
+
+## Configuration
+
+### Timeout
+
+```python
+client = Client(
+    api_key="your-api-key",
+    timeout=30.0  # 30 second timeout
+)
+```
+
+### Environment Variables
+
+```python
+import os
+from lean_explore.api.client import Client
+
+api_key = os.getenv("LEAN_EXPLORE_API_KEY")
+base_url = os.getenv("LEAN_EXPLORE_BASE_URL")
+
+client = Client(api_key=api_key, base_url=base_url)
+```
+
+## Next Steps
+
+- [API Reference](../api-reference/api-client.md) - Complete API documentation
+- [HTTP Server](http-server.md) - Run a local HTTP server
+- [Local Search](local-search.md) - Use local backend
+

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -1,0 +1,202 @@
+# CLI Usage
+
+The Lean Explore command-line interface provides easy access to search functionality and server management.
+
+## Overview
+
+The CLI is accessed via the `leanexplore` command:
+
+```bash
+leanexplore [OPTIONS] COMMAND [ARGS]...
+```
+
+## Commands
+
+### Search
+
+Search for Lean declarations:
+
+```bash
+leanexplore search QUERY [OPTIONS]
+```
+
+**Options:**
+- `--pkg, -p`: Filter by package name (can be specified multiple times)
+- `--limit, -n`: Maximum number of results (default: 10)
+
+**Examples:**
+
+```bash
+# Basic search
+leanexplore search "natural numbers"
+
+# Search with package filter
+leanexplore search "monoid" --pkg Mathlib
+
+# Multiple package filters
+leanexplore search "group" --pkg Mathlib --pkg Batteries
+
+# Limit results
+leanexplore search "topology" --limit 5
+```
+
+### Configure
+
+Manage CLI configuration:
+
+```bash
+leanexplore configure COMMAND
+```
+
+**Subcommands:**
+
+- `api-key KEY`: Set API key for remote API
+- `show`: Display current configuration
+- `reset`: Reset configuration to defaults
+
+**Examples:**
+
+```bash
+# Set API key
+leanexplore configure api-key YOUR_API_KEY
+
+# View configuration
+leanexplore configure show
+
+# Reset configuration
+leanexplore configure reset
+```
+
+### HTTP Server
+
+Start a local HTTP server:
+
+```bash
+leanexplore http start [OPTIONS]
+```
+
+**Options:**
+- `--backend`: Backend type (`api` or `local`)
+- `--api-key`: API key (required for `api` backend)
+- `--host`: Host to bind to (default: `127.0.0.1`)
+- `--port`: Port to bind to (default: `8000`)
+
+**Examples:**
+
+```bash
+# Start with API backend
+leanexplore http start --backend api --api-key YOUR_API_KEY
+
+# Start with local backend
+leanexplore http start --backend local
+
+# Custom host and port
+leanexplore http start --backend local --host 0.0.0.0 --port 8080
+```
+
+### MCP Server
+
+Start the Model Context Protocol server:
+
+```bash
+leanexplore mcp start [OPTIONS]
+```
+
+**Options:**
+- `--backend`: Backend type (`api` or `local`)
+- `--api-key`: API key (required for `api` backend)
+- `--log-level`: Logging level (default: `INFO`)
+
+**Examples:**
+
+```bash
+# Start with API backend
+leanexplore mcp start --backend api --api-key YOUR_API_KEY
+
+# Start with local backend
+leanexplore mcp start --backend local
+```
+
+### Data Management
+
+Manage local data:
+
+```bash
+leanexplore data COMMAND
+```
+
+**Subcommands:**
+
+- `fetch`: Download local data files
+- `list`: List available data toolchains
+- `status`: Check data status
+
+**Examples:**
+
+```bash
+# Fetch local data
+leanexplore data fetch
+
+# List available toolchains
+leanexplore data list
+
+# Check data status
+leanexplore data status
+```
+
+### Chat
+
+Interact with an AI agent using Lean Explore tools:
+
+```bash
+leanexplore chat [OPTIONS]
+```
+
+**Options:**
+- `--model`: Model to use (default: `gpt-4`)
+- `--backend`: Backend type (`api` or `local`)
+- `--api-key`: API key (required for `api` backend)
+
+**Examples:**
+
+```bash
+# Start chat session
+leanexplore chat
+
+# Use specific model
+leanexplore chat --model gpt-4-turbo
+
+# Use local backend
+leanexplore chat --backend local
+```
+
+## Global Options
+
+- `--help, -h`: Show help message
+- `--version`: Show version information
+
+## Examples
+
+### Complete Workflow
+
+```bash
+# 1. Configure API key
+leanexplore configure api-key YOUR_API_KEY
+
+# 2. Search for declarations
+leanexplore search "natural numbers"
+
+# 3. Start local server
+leanexplore data fetch
+leanexplore http start --backend local
+
+# 4. Query the server
+curl "http://localhost:8000/api/v1/search?q=natural+numbers"
+```
+
+## Next Steps
+
+- [API Client](api-client.md) - Use the Python API
+- [HTTP Server](http-server.md) - Run a local HTTP server
+- [MCP Server](mcp-server.md) - Integrate with AI agents
+

--- a/docs/user-guide/http-server.md
+++ b/docs/user-guide/http-server.md
@@ -1,0 +1,136 @@
+# HTTP Server
+
+Run a local HTTP server that provides the same API as the remote Lean Explore service.
+
+## Starting the Server
+
+### Using API Backend
+
+```bash
+leanexplore http start --backend api --api-key YOUR_API_KEY
+```
+
+This starts a server that proxies requests to the remote API.
+
+### Using Local Backend
+
+```bash
+# First, fetch local data
+leanexplore data fetch
+
+# Start server with local backend
+leanexplore http start --backend local
+```
+
+### Custom Configuration
+
+```bash
+# Custom host and port
+leanexplore http start --backend local --host 0.0.0.0 --port 8080
+```
+
+## API Endpoints
+
+The server provides the same endpoints as the remote API:
+
+### Search
+
+```bash
+GET /api/v1/search?q=QUERY&pkg=PACKAGE
+```
+
+**Parameters:**
+- `q` (required): Search query string
+- `pkg` (optional): Package filter (can be specified multiple times)
+
+**Example:**
+
+```bash
+curl "http://localhost:8000/api/v1/search?q=natural+numbers"
+```
+
+**Response:**
+
+```json
+{
+  "query": "natural numbers",
+  "items": [
+    {
+      "id": 123,
+      "primary_declaration": {
+        "lean_name": "Nat",
+        "decl_type": "structure"
+      },
+      "informal_name": "Natural numbers",
+      "informal_description": "...",
+      "score": 0.95
+    }
+  ]
+}
+```
+
+### Get Citations
+
+```bash
+GET /api/v1/citations/{item_id}
+```
+
+**Example:**
+
+```bash
+curl "http://localhost:8000/api/v1/citations/123"
+```
+
+**Response:**
+
+```json
+{
+  "citations": [
+    {
+      "lean_name": "Nat.add",
+      "decl_type": "def"
+    }
+  ]
+}
+```
+
+## Using with Python Client
+
+You can use the Python client with a local server:
+
+```python
+from lean_explore.api.client import Client
+
+# Connect to local server
+client = Client(base_url="http://localhost:8000")
+
+# Use as normal
+results = await client.search("natural numbers")
+```
+
+## OpenAPI Documentation
+
+The server provides OpenAPI documentation at:
+
+- Swagger UI: `http://localhost:8000/docs`
+- ReDoc: `http://localhost:8000/redoc`
+- OpenAPI JSON: `http://localhost:8000/openapi.json`
+
+## Backend Comparison
+
+### API Backend
+
+- **Pros**: No local data required, always up-to-date
+- **Cons**: Requires API key, network access needed
+
+### Local Backend
+
+- **Pros**: No API key needed, works offline, faster for repeated queries
+- **Cons**: Requires local data download, may be out of date
+
+## Next Steps
+
+- [CLI Usage](cli.md) - Command-line interface
+- [API Client](api-client.md) - Python API client
+- [MCP Server](mcp-server.md) - Model Context Protocol server
+

--- a/docs/user-guide/local-search.md
+++ b/docs/user-guide/local-search.md
@@ -1,0 +1,116 @@
+# Local Search
+
+Use Lean Explore with a local backend for offline access and faster queries.
+
+## Setup
+
+### Fetch Local Data
+
+First, download the necessary data files:
+
+```bash
+leanexplore data fetch
+```
+
+This downloads:
+- SQLite database with declarations
+- FAISS index for semantic search
+- Embedding model files
+- ID mapping files
+
+### Verify Data
+
+Check that data is available:
+
+```bash
+leanexplore data status
+```
+
+## Using Local Backend
+
+### CLI
+
+```bash
+# Search using local backend
+leanexplore search "natural numbers" --backend local
+```
+
+### Python API
+
+```python
+from lean_explore.local.service import Service
+
+# Initialize local service
+service = Service()
+
+# Search
+results = await service.search("natural numbers")
+
+# Process results
+for item in results.items:
+    print(item.primary_declaration.lean_name)
+```
+
+### HTTP Server
+
+```bash
+# Start server with local backend
+leanexplore http start --backend local
+```
+
+Then query via HTTP:
+
+```bash
+curl "http://localhost:8000/api/v1/search?q=natural+numbers"
+```
+
+## Configuration
+
+### Custom Data Directory
+
+```python
+from lean_explore.local.service import Service
+
+service = Service(data_dir="/path/to/custom/data")
+```
+
+### Custom Database URL
+
+```python
+from lean_explore.local.service import Service
+
+service = Service(
+    db_url="sqlite:///path/to/database.db"
+)
+```
+
+## Advantages of Local Backend
+
+- **Offline Access**: No internet connection required
+- **Faster Queries**: No network latency
+- **Privacy**: Data stays on your machine
+- **No API Key**: No authentication needed
+- **Customizable**: Full control over data and configuration
+
+## Data Updates
+
+To update your local data:
+
+```bash
+leanexplore data fetch
+```
+
+This will download the latest data files.
+
+## Storage Location
+
+By default, data is stored in:
+- **macOS/Linux**: `~/.leanexplore/data`
+- **Windows**: `%APPDATA%\leanexplore\data`
+
+## Next Steps
+
+- [CLI Usage](cli.md) - Command-line interface
+- [API Client](api-client.md) - Python API client
+- [HTTP Server](http-server.md) - HTTP API server
+

--- a/docs/user-guide/mcp-server.md
+++ b/docs/user-guide/mcp-server.md
@@ -1,0 +1,126 @@
+# MCP Server
+
+The Model Context Protocol (MCP) server allows AI agents to interact with Lean Explore.
+
+## Overview
+
+MCP is a protocol that enables AI assistants to access external tools and data sources. The Lean Explore MCP server provides tools for searching Lean declarations and exploring their relationships.
+
+## Starting the Server
+
+### Using API Backend
+
+```bash
+leanexplore mcp start --backend api --api-key YOUR_API_KEY
+```
+
+### Using Local Backend
+
+```bash
+# First, fetch local data
+leanexplore data fetch
+
+# Start MCP server
+leanexplore mcp start --backend local
+```
+
+### Custom Logging
+
+```bash
+leanexplore mcp start --backend local --log-level DEBUG
+```
+
+## Available Tools
+
+The MCP server provides the following tools:
+
+### Search
+
+Search for Lean declarations using natural language queries.
+
+**Parameters:**
+- `query` (string, required): The search query
+- `package_filters` (array of strings, optional): Package names to filter by
+
+**Example:**
+
+```json
+{
+  "name": "lean_explore_search",
+  "arguments": {
+    "query": "natural numbers",
+    "package_filters": ["Mathlib"]
+  }
+}
+```
+
+### Get Statement Group
+
+Retrieve detailed information about a specific statement group.
+
+**Parameters:**
+- `statement_group_id` (integer, required): The ID of the statement group
+
+**Example:**
+
+```json
+{
+  "name": "lean_explore_get_statement_group",
+  "arguments": {
+    "statement_group_id": 123
+  }
+}
+```
+
+### Get Citations
+
+Get declarations that cite a specific statement group.
+
+**Parameters:**
+- `statement_group_id` (integer, required): The ID of the statement group
+
+**Example:**
+
+```json
+{
+  "name": "lean_explore_get_citations",
+  "arguments": {
+    "statement_group_id": 123
+  }
+}
+```
+
+## Integration
+
+### With Claude Desktop
+
+Add to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "lean-explore": {
+      "command": "leanexplore",
+      "args": ["mcp", "start", "--backend", "api", "--api-key", "YOUR_API_KEY"]
+    }
+  }
+}
+```
+
+### With Other MCP Clients
+
+The server communicates via stdio using the MCP protocol. Any MCP-compatible client can connect to it.
+
+## Use Cases
+
+- **AI Code Assistants**: Help AI assistants understand and search Lean code
+- **Documentation Generation**: Automatically generate documentation from Lean code
+- **Code Exploration**: Enable AI agents to explore Lean codebases
+- **Research Tools**: Assist in mathematical research by finding relevant theorems
+
+## Next Steps
+
+- [CLI Usage](cli.md) - Command-line interface
+- [API Client](api-client.md) - Python API client
+- [HTTP Server](http-server.md) - HTTP API server
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,105 @@
+site_name: Lean Explore
+site_description: A search engine for Lean 4 declarations
+site_author: Lean Explore Contributors
+site_url: https://kellyjdavis.github.io/lean-explore
+
+repo_name: KellyJDavis/lean-explore
+repo_url: https://github.com/KellyJDavis/lean-explore
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.annotate
+    - content.code.copy
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - admonition
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_root_toc_entry: true
+            show_root_full_path: false
+            show_object_full_path: false
+            show_category_heading: true
+            show_if_no_docstring: false
+            separate_signature: true
+            merge_init_into_class: true
+            show_submodules: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Quick Start: getting-started/quickstart.md
+    - Configuration: getting-started/configuration.md
+  - User Guide:
+    - CLI Usage: user-guide/cli.md
+    - API Client: user-guide/api-client.md
+    - HTTP Server: user-guide/http-server.md
+    - MCP Server: user-guide/mcp-server.md
+    - Local Search: user-guide/local-search.md
+  - API Reference:
+    - API Client: api-reference/api-client.md
+    - HTTP Server: api-reference/http-server.md
+    - Local Service: api-reference/local-service.md
+    - MCP Tools: api-reference/mcp-tools.md
+    - Models: api-reference/models.md
+  - Development:
+    - Scripts: development/scripts.md
+    - Data Pipeline: development/data-pipeline.md
+    - Contributing: development/contributing.md
+  - Examples: examples.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/KellyJDavis/lean-explore
+  version:
+    provider: mike
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "lean-explore"
+name = "lean-xplore"
 version = "0.3.0"
 authors = [
     { name = "Justin Asher", email = "justinchadwickasher@gmail.com" },
@@ -69,6 +69,12 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "pytest-mock>=3.10.0",
     "ruff>=0.1.0",
+]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.0.0",
+    "mkdocstrings[python]>=0.24.0",
+    "pymdown-extensions>=10.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
- Change package name from "lean-explore" to "lean-xplore" in pyproject.toml for PyPI publication

- Add comprehensive MkDocs documentation setup:
  * Create mkdocs.yml with Material theme configuration
  * Add complete documentation structure (getting started, user guide, API reference, development guides)
  * Set up GitHub Actions workflow for automatic deployment to GitHub Pages
  * Documentation will be available at kellyjdavis.github.io/lean-explore

- Enhance README.md with detailed installation and usage instructions:
  * Add features overview
  * Include API key setup instructions
  * Expand command-line and Python API examples
  * Add local backend usage guide
  * Document additional features (MCP server, HTTP server, AI chat)

- Update pyproject.toml:
  * Add "docs" optional dependency group with MkDocs packages

- Update Makefile:
  * Add "docs" target to build documentation
  * Add "docs-serve" target for local development
  * Update clean target to remove site/ directory

This commit prepares the repository for PyPI publication and provides comprehensive documentation for users and contributors.