### PR TITLE
fix: support version detection in both development and installed envi…

### DIFF
--- a/src/lean_explore/defaults.py
+++ b/src/lean_explore/defaults.py
@@ -73,7 +73,7 @@ DEFAULT_DB_URL: Final[str] = f"sqlite:///{DEFAULT_DB_PATH.resolve()}"
 
 # Helper function to get the project version
 def _get_project_version() -> str:
-    """Reads the project version from pyproject.toml (development) or package metadata (installed).
+    """Reads the project version from pyproject.toml or package metadata.
 
     First tries to read from pyproject.toml for development environments.
     Falls back to reading from installed package metadata for installed packages.


### PR DESCRIPTION
…ronments

The _get_project_version() function previously only read from pyproject.toml, which caused a FileNotFoundError when the package was installed from PyPI since pyproject.toml is not included in installed packages.

This change adds a fallback mechanism that:
- First attempts to read from pyproject.toml (for development environments)
- Falls back to reading from package metadata via importlib.metadata when pyproject.toml is not available (for installed packages)

Fixes the issue where `leanexplore --help` would fail with a RuntimeError after installing the package from PyPI.