### PR TITLE
Add CI workflow to run tests on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Run Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]"
+
+      - name: Run all tests
+        run: make test-all
+


### PR DESCRIPTION
Add GitHub Actions workflow that runs 'make test-all' on pull requests and pushes to main branch. This ensures all tests (including slow, integration, and external tests) pass before code is merged.

The workflow:
- Runs on pull_request and push to main
- Uses Python 3.12
- Installs package with dev dependencies
- Executes make test-all with coverage reporting